### PR TITLE
Refactor: Modularize Vue application into separate components

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,0 +1,28 @@
+/* Global styles that apply to the body or root elements */
+body { 
+    font-family: 'Inter', sans-serif;
+    /* Ensure body takes full height if not already handled by Tailwind on html/body in index.html */
+    /* The App.vue template uses h-screen on the root div, which is good. */
+    /* Tailwind's preflight typically handles base font settings, but explicit here is fine. */
+}
+
+:root { 
+    font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif; 
+}
+
+/* Styles for generic modal appearance (backdrop, basic modal content animation) */
+/* These are used by the base Modal.vue component */
+.modal-backdrop { 
+    background-color: rgba(0, 0, 0, 0.6); 
+}
+.modal-content { 
+    transform: scale(0.95); 
+    opacity: 0; 
+    animation: modal-appear 0.3s forwards; 
+}
+@keyframes modal-appear { 
+    to { 
+        opacity: 1; 
+        transform: scale(1); 
+    } 
+}

--- a/src/components/AboutModal.vue
+++ b/src/components/AboutModal.vue
@@ -1,0 +1,38 @@
+<template>
+  <Modal :is-open="props.isOpen" :title="props.title" :width-class="props.widthClass" @close="emit('close')">
+    <p class="text-gray-300 mb-2"><strong>Version :</strong> 1.1.0-alpha</p>
+    <p class="text-gray-300 mb-4"><strong>Auteur :</strong> Charles-Antoine Huberdeau</p>
+    <div class="border-t border-slate-700 pt-4 mt-4">
+      <h4 class="text-md font-semibold mb-2 text-gray-200">Technologies :</h4>
+      <ul class="list-disc list-inside text-sm text-gray-400">
+        <li>Vue.js 3</li><li>Tailwind CSS</li><li>Font Awesome</li>
+      </ul>
+    </div>
+    <div class="flex justify-end mt-6">
+      <button @click="emit('close')" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">Fermer</button>
+    </div>
+  </Modal>
+</template>
+
+<script setup>
+import { defineProps, defineEmits } from 'vue';
+import Modal from './Modal.vue'; // Assuming Modal.vue is in the same components directory
+
+const props = defineProps({
+  isOpen: Boolean,
+  title: {
+    type: String,
+    default: "À propos de Carte Mentale Interactive" // Default title
+  },
+  widthClass: {
+    type: String,
+    default: 'max-w-md' // Default width class
+  }
+});
+
+const emit = defineEmits(['close']);
+</script>
+
+<style scoped>
+/* No specific styles needed if Tailwind is handling everything and Modal.vue has its own styles */
+</style>

--- a/src/components/ErrorModal.vue
+++ b/src/components/ErrorModal.vue
@@ -1,0 +1,35 @@
+<template>
+  <Modal :is-open="props.isOpen" :title="props.title" @close="emit('close')">
+    <p class="mb-4" :class="typeClass">{{ props.message }}</p>
+    <div class="flex justify-end">
+      <button @click="emit('close')" class="px-4 py-2 bg-slate-600 text-gray-200 hover:bg-slate-500 rounded transition-colors">Fermer</button>
+    </div>
+  </Modal>
+</template>
+
+<script setup>
+import { computed, defineProps, defineEmits } from 'vue';
+import Modal from './Modal.vue'; // Assuming Modal.vue is in the same components directory
+
+const props = defineProps({
+  isOpen: Boolean,
+  title: String,
+  message: String,
+  type: { // For 'error', 'success', 'info'
+    type: String,
+    default: 'error' // Default to error type
+  }
+});
+
+const emit = defineEmits(['close']);
+
+const typeClass = computed(() => {
+  if (props.type === 'success') return 'text-green-400';
+  if (props.type === 'info') return 'text-blue-400';
+  return 'text-red-400'; // Default to error
+});
+</script>
+
+<style scoped>
+/* No specific styles needed if Tailwind is handling everything and Modal.vue has its own styles */
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import { createApp } from 'vue';
 import App from './App.vue';
-// import './assets/main.css'; // We'll create this later if needed
+import './assets/main.css'; // Add this line
 
 createApp(App).mount('#app');


### PR DESCRIPTION
This commit completes a major refactoring of the mind map application. The single HTML file has been restructured into a Vue project with multiple components:

- `index.html`: Minimal host page.
- `src/main.js`: Initializes the Vue app and loads global CSS.
- `src/App.vue`: Main application component, orchestrates child components and manages shared state.
- `src/components/`:
    - `Modal.vue`: Generic modal wrapper.
    - `Toolbar.vue`: Application toolbar.
    - `MindMapCanvas.vue`: Core canvas rendering and interaction logic.
    - `ContextMenu.vue`: Node context menu.
    - `FileMenu.vue`: File operations menu.
    - Specific modal dialogs: `TextEditModal.vue`, `HyperlinkModal.vue`, `ImagePreviewModal.vue`, `DeleteConfirmModal.vue`, `ErrorModal.vue`, `AboutModal.vue`.
- `src/assets/main.css`: Global styles.

Key changes:
- Renamed `carte-mental-alpha-3.html` to `index.html`.
- Extracted UI, logic, and styles into respective single-file components.
- Established clear prop/event communication between `App.vue` and child components.
- Centralized global styles.
- Cleaned up and removed unused code from `App.vue`.

This refactoring significantly improves code organization, maintainability, and scalability of the application.